### PR TITLE
Allow translate function to take in target_lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ translator.translate('Engineering physics or engineering science').then(translat
     //Do something with the translated text
 });
 ```
+You can also pass in an optional language parameter to translate to desire languagues (default use current config)
+```
+const translator = TranslatorFactory.createTranslator();
+translator.translate('Engineering physics or engineering science', 'fr').then(translated => {
+    //Do something with the translated text which would be in French
+});
+```
 
 ## Complete reference
 * **PowerTranslator**: A react component to translate your texts.

--- a/src/services/GoogleTranslator.js
+++ b/src/services/GoogleTranslator.js
@@ -11,7 +11,7 @@ export default class GoogleTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text, lang = "") {
+    translate(text, lang = '') {
       if (lang)  this.config.targetLanguage = lang;
       const url = `${GOOGLE.TRANSLATE}${this.config.apiKey}`;
       const data = this.createTheRequest(text);

--- a/src/services/GoogleTranslator.js
+++ b/src/services/GoogleTranslator.js
@@ -11,7 +11,8 @@ export default class GoogleTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text) {
+    translate(text, lang = "") {
+      if (lang)  this.config.targetLanguage = lang;
       const url = `${GOOGLE.TRANSLATE}${this.config.apiKey}`;
       const data = this.createTheRequest(text);
 

--- a/src/services/MicrosoftTranslator.js
+++ b/src/services/MicrosoftTranslator.js
@@ -13,7 +13,8 @@ export default class MicrosoftTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text) {
+    translate(text, lang = "") {
+      if (lang)  this.config.targetLanguage = lang;
       const url = this.createTheRequest(text);
       const header = {
         headers: {

--- a/src/services/MicrosoftTranslator.js
+++ b/src/services/MicrosoftTranslator.js
@@ -13,7 +13,7 @@ export default class MicrosoftTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text, lang = "") {
+    translate(text, lang = '') {
       if (lang)  this.config.targetLanguage = lang;
       const url = this.createTheRequest(text);
       const header = {


### PR DESCRIPTION
I added an optional parameter for target languages (It is optional, so that people who had older versions of this code won't get a compile error). Thus, now this function can quickly convert to many languages. Users can create many instances of this service to translate to multiple languages on the same page.