### PR TITLE
Allowing source language to be an optional paramete

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ translator.translate('Engineering physics or engineering science', 'fr').then(tr
 });
 ```
 
+You can specify optional source language (otherwise it autodetects) 
+
+```
+const translator = TranslatorFactory.createTranslator();
+translator.translate('chair', 'en', 'fr').then(translated => {
+    //Chair has different meaning in French/English
+});
+```
+
+
 ## Complete reference
 * **PowerTranslator**: A react component to translate your texts.
 * **ProviderTypes**: List of the cloud provider types. There are two providers is available. ProvierTypes.Google for [google translate](https://cloud.google.com/translate/docs/) and ProviderTypes.Microsoft for [microsoft translator text](https://azure.microsoft.com/en-us/services/cognitive-services/translator-text-api/) cloud service.

--- a/src/services/GoogleTranslator.js
+++ b/src/services/GoogleTranslator.js
@@ -13,7 +13,14 @@ export default class GoogleTranslator extends BaseTranslator {
 
     translate(text, lang = '', src_lang = '') {
       if (lang)  this.config.targetLanguage = lang;
-      if (src_lang)  this.config.sourceLanguage = src_lang;
+      if (src_lang){
+         this.config.sourceLanguage = src_lang;
+         this.config.source = true;
+      }
+      else {
+          this.config.source = false; 
+      }
+
       const url = `${GOOGLE.TRANSLATE}${this.config.apiKey}`;
       const data = this.createTheRequest(text);
 

--- a/src/services/GoogleTranslator.js
+++ b/src/services/GoogleTranslator.js
@@ -11,8 +11,9 @@ export default class GoogleTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text, lang = '') {
+    translate(text, lang = '', src_lang = '') {
       if (lang)  this.config.targetLanguage = lang;
+      if (src_lang)  this.config.sourceLanguage = src_lang;
       const url = `${GOOGLE.TRANSLATE}${this.config.apiKey}`;
       const data = this.createTheRequest(text);
 

--- a/src/services/MicrosoftTranslator.js
+++ b/src/services/MicrosoftTranslator.js
@@ -13,8 +13,9 @@ export default class MicrosoftTranslator extends BaseTranslator {
       this.config = config;
     }
 
-    translate(text, lang = '') {
+    translate(text, lang = '', src_lang = '') {
       if (lang)  this.config.targetLanguage = lang;
+      if (src_lang)  this.config.sourceLanguage = src_lang;
       const url = this.createTheRequest(text);
       const header = {
         headers: {

--- a/src/services/MicrosoftTranslator.js
+++ b/src/services/MicrosoftTranslator.js
@@ -15,7 +15,14 @@ export default class MicrosoftTranslator extends BaseTranslator {
 
     translate(text, lang = '', src_lang = '') {
       if (lang)  this.config.targetLanguage = lang;
-      if (src_lang)  this.config.sourceLanguage = src_lang;
+      if (src_lang){
+         this.config.sourceLanguage = src_lang;
+         this.config.source = true;
+      }
+      else {
+          this.config.source = false; 
+      }
+        
       const url = this.createTheRequest(text);
       const header = {
         headers: {


### PR DESCRIPTION
I came across this problem when I am designing my app: 
Some words have different meaning in different language (lots of words in English have the same spelling as French, but we do not know what the source language is when the API auto detect language).

Hope this help! 