### PR TITLE
Update MicrosoftTranslator.js to fix xmldom could not be found within…

### DIFF
--- a/src/services/MicrosoftTranslator.js
+++ b/src/services/MicrosoftTranslator.js
@@ -2,8 +2,7 @@ import HTTPMethods from './HTTPMethods';
 import { MICROSOFT } from '../Constants';
 import BaseTranslator from './BaseTranslator';
 import htmlEntities from './HtmlUtility';
-
-const DOMParser = require('xmldom').DOMParser;
+import { DOMParser } from '@xmldom/xmldom'
 
 export default class MicrosoftTranslator extends BaseTranslator {
     config;


### PR DESCRIPTION
… the project or in these directories

Due to recent update to xmldom. https://www.npmjs.com/package/@xmldom/xmldom.  The line 'const DOMParser = require('xmldom').DOMParser' gives an error 'xmldom could not be found within the project or in these directories'